### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -27,4 +27,4 @@ Authors
 
 Invenio module makes your site Memento compliant.
 
-- CERN <info@invenio-software.org>
+- CERN <info@inveniosoftware.org>

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Memento.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-memento
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -35,7 +35,7 @@ Initialize database
 
 Create a user (for accessing admin):
 
-   $ flask -a app.py users create info@invenio-software.org -a
+   $ flask -a app.py users create info@inveniosoftware.org -a
 
 Load some test data:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_memento/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_memento/translations/messages.pot
 add-comments = NOTE

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
     keywords='invenio memento files',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-memento',
     packages=packages,
     zip_safe=False,


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
