### PR TITLE
installation: renaming of entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
         # 'invenio_base.api_apps': [],
         # 'invenio_base.api_blueprints': [],
         'invenio_base.blueprints': [
-            'invenio_memento = invenio_memento.view:blueprint',
+            'invenio_memento = invenio_memento.views:blueprint',
         ],
         'invenio_db.models': [
             'invenio_memento = invenio_memento.models',


### PR DESCRIPTION
* Fixes invenio_base.blueprints entry point,
  renaming invenio_memento.view to invenio_memento.views

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>